### PR TITLE
Reorganize course repo into structured lesson toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,45 @@
-# ART215_SP22
-Code for my web design course at Augsburg University
+# ART215 // Web Design Toolkit
 
-Students, feel free to clone anything that you see here that you haven't gotten while we were in class.
-Others, welcome - if you have ideas, please share!
+Welcome to the reorganized ART215 playground — a lean, loud toolkit for teaching and learning the fundamentals of web design. This repo is now structured as a set of guided lessons, remix-friendly exercises, and project starters so you can run class straight from the command line (or let students self-direct like the legends they are).
+
+## Quick start
+
+1. **Clone or download** this repo. Hand it to your class or fork it for your own remix.
+2. **Open the lesson you want** inside the `lessons/` folder. Each one ships with an explainer README plus runnable HTML/CSS/JS.
+3. **Serve the files locally** however you like. A quick option: `python3 -m http.server 8080` from the lesson folder and visit <http://localhost:8080>.
+4. **Tweak, break, rebuild.** Every example is meant to be edited live so students can see the immediate impact.
+
+## Repo layout at a glance
+
+| Directory | What you’ll find | Classroom use |
+| --- | --- | --- |
+| `lessons/` | Step-by-step guided walkthroughs with sample code. | Live demos, flipped classroom prep, or asynchronous refreshers. |
+| `exercises/` | Bite-sized challenges with clear success criteria. | Studio work, assessments, or extra-credit chaos. |
+| `projects/` | Longer-form build prompts and starter files. | Capstones, portfolios, or collaborative sprints. |
+| `resources/` | Curated links and cheatsheets. | Shareable reference material to keep curiosity stoked. |
+
+Every folder has its own README that spells out intent, objectives, and extension ideas so you can riff or assign without reinventing the wheel.
+
+## Teaching flow suggestions
+
+- **Lesson ➡ Exercise ➡ Project:** Start with a guided lesson, reinforce with a quick exercise, then let students expand in a project starter.
+- **Swap order freely:** Modules are intentionally independent. Need to hammer layout before semantics? Go for it.
+- **Encourage commits:** Have students snapshot experiments with Git so they can track their evolution and build a portfolio narrative.
+
+## Built-in differentiation tips
+
+- Most lessons include stretch ideas for advanced students and “safety net” notes for those who need more scaffolding.
+- Exercises flag required vs. optional steps, so you can dial complexity up or down mid-flight.
+- Project starters include critique prompts — great for peer reviews or self-reflection journals.
+
+## Remixing the toolkit
+
+- **Add your own lessons:** Copy an existing lesson folder, rename it with the next number, and rewrite the README with your objectives.
+- **Localize content:** Swap imagery, typography, or prompts to reflect your students’ communities and interests.
+- **Version the semester:** Tag releases per semester so you keep a record of what you shipped and what the students smashed.
+
+## Need help or have ideas?
+
+Open an issue or drop a pull request with suggestions. This repo is deliberately open-ended — if you have an assignment that rocked your class, throw it in here so others can build on it.
+
+Stay curious, stay kind, and build the web you want to see.

--- a/exercises/01-wireframe-to-web/README.md
+++ b/exercises/01-wireframe-to-web/README.md
@@ -1,0 +1,25 @@
+# Exercise 01 · Wireframe to Web (30-minute sprint)
+
+## Purpose
+Convert a grayscale wireframe into working HTML/CSS. Students practice reading design intent, choosing semantic tags, and applying responsive layout techniques from Lessons 01 and 02.
+
+## Setup
+- Open `starter.html` and `styles.css` in your editor.
+- Reference the `wireframe.svg` from Lesson 02 for the layout goals.
+- Timer suggestion: 25 minutes build + 5 minutes reflection.
+
+## Success criteria
+- Semantic structure mirrors the wireframe (header, main sections, footer).
+- Layout adapts gracefully at 320px, 768px, and 1024px widths.
+- Typography and spacing tokens use CSS custom properties for consistency.
+
+## Submission options
+- Commit your work with a descriptive message (`feat: complete wireframe sprint`).
+- Record a quick walkthrough video or Loom explaining your decisions.
+
+## Remix ideas
+- Swap the color palette and explain how it shifts the mood.
+- Translate the copy into another language and adjust spacing accordingly.
+- Add a “stretch goal” component (like a testimonial) and annotate it in comments.
+
+The `solution/` folder offers one approach if you need a reference or want to run a critique session.

--- a/exercises/01-wireframe-to-web/solution/README.md
+++ b/exercises/01-wireframe-to-web/solution/README.md
@@ -1,0 +1,3 @@
+# Suggested Solution
+
+One possible approach to the wireframe sprint. Use it for reference, critique, or to build extension activities. Encourage students to compare their decisions with this version rather than copy-paste it blindly.

--- a/exercises/01-wireframe-to-web/solution/index.html
+++ b/exercises/01-wireframe-to-web/solution/index.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Community Skills Week</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="brand">
+        <p class="eyebrow">Community Skills Week</p>
+        <h1>Workshops for curious neighbors</h1>
+      </div>
+      <nav aria-label="Primary">
+        <ul class="nav-links">
+          <li><a href="#schedule">Schedule</a></li>
+          <li><a href="#speakers">Speakers</a></li>
+          <li><a href="#register">Register</a></li>
+        </ul>
+      </nav>
+    </header>
+
+    <main>
+      <section id="schedule" class="feature">
+        <h2>Three days of making and sharing</h2>
+        <p>
+          Each day pairs hands-on workshops with community conversations. Choose a track or mix sessions that energize you.
+        </p>
+        <a class="button" href="#register">Grab a pass</a>
+      </section>
+
+      <section id="speakers" class="grid">
+        <article>
+          <h3>Day 1 · Storytelling</h3>
+          <p>Build podcast kits, zines, and oral history archives with local organizers.</p>
+        </article>
+        <article>
+          <h3>Day 2 · Repair &amp; reuse</h3>
+          <p>Fix small electronics, mend clothing, and swap repair hacks.</p>
+        </article>
+        <article>
+          <h3>Day 3 · Digital care</h3>
+          <p>Design accessible sites and digital mutual aid tools for your neighborhood.</p>
+        </article>
+      </section>
+    </main>
+
+    <footer id="register" class="site-footer">
+      <h2>Sliding scale tickets</h2>
+      <p>Pay what you can. Proceeds fund future free programming.</p>
+      <a class="button" href="#">Register now</a>
+    </footer>
+  </body>
+</html>

--- a/exercises/01-wireframe-to-web/solution/styles.css
+++ b/exercises/01-wireframe-to-web/solution/styles.css
@@ -1,0 +1,133 @@
+:root {
+  color-scheme: only light;
+  --space-xs: 0.5rem;
+  --space-sm: 1rem;
+  --space-md: 1.5rem;
+  --space-lg: 2.5rem;
+  --space-xl: 4rem;
+  --radius: 1.5rem;
+  --color-bg: #0f172a;
+  --color-surface: rgba(17, 24, 39, 0.8);
+  --color-highlight: #38bdf8;
+  --color-text: #f8fafc;
+  --color-muted: #cbd5f5;
+  font-family: "Inter", system-ui, sans-serif;
+  line-height: 1.6;
+}
+
+body {
+  margin: 0;
+  background: radial-gradient(circle at top, #1d4ed8, #0b1120 55%);
+  color: var(--color-text);
+  min-height: 100vh;
+  padding: var(--space-lg) var(--space-sm) var(--space-xl);
+}
+
+main,
+.site-header,
+.site-footer {
+  background-color: var(--color-surface);
+  backdrop-filter: blur(12px);
+  padding: var(--space-lg) var(--space-md);
+  border-radius: var(--radius);
+  max-width: 68rem;
+  margin: 0 auto var(--space-lg);
+  box-shadow: 0 1.5rem 3rem rgba(15, 23, 42, 0.35);
+}
+
+.site-header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.eyebrow {
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  font-size: 0.9rem;
+  color: var(--color-muted);
+}
+
+.nav-links {
+  list-style: none;
+  display: flex;
+  gap: var(--space-sm);
+  padding: 0;
+}
+
+.nav-links a {
+  color: var(--color-text);
+  text-decoration: none;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+}
+
+.nav-links a:focus,
+.nav-links a:hover {
+  border-color: var(--color-highlight);
+}
+
+.feature {
+  text-align: center;
+}
+
+.button {
+  display: inline-block;
+  margin-top: var(--space-sm);
+  padding: 0.65rem 1.5rem;
+  background: linear-gradient(135deg, #38bdf8, #6366f1);
+  color: #0b1120;
+  border-radius: 999px;
+  text-decoration: none;
+  font-weight: 700;
+}
+
+.grid {
+  display: grid;
+  gap: var(--space-sm);
+}
+
+.grid article {
+  background: rgba(15, 23, 42, 0.65);
+  padding: var(--space-sm);
+  border-radius: calc(var(--radius) - 0.5rem);
+  box-shadow: inset 0 0 0 1px rgba(59, 130, 246, 0.25);
+}
+
+.site-footer {
+  text-align: center;
+}
+
+@media (min-width: 48rem) {
+  .site-header {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  .feature {
+    text-align: left;
+    display: grid;
+    grid-template-columns: 3fr 1fr;
+    align-items: center;
+    gap: var(--space-md);
+  }
+
+  .grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 72rem) {
+  main {
+    display: grid;
+    grid-template-columns: 2fr 3fr;
+    gap: var(--space-lg);
+    align-items: start;
+  }
+
+  #speakers {
+    grid-column: span 2;
+  }
+}

--- a/exercises/01-wireframe-to-web/starter.html
+++ b/exercises/01-wireframe-to-web/starter.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Wireframe Sprint Starter</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header>
+      <!-- TODO: Add page title and navigation -->
+    </header>
+
+    <main>
+      <!-- TODO: Replace placeholder sections with semantic structure -->
+      <section>
+        <h2>Section heading</h2>
+        <p>Describe the section here.</p>
+      </section>
+    </main>
+
+    <footer>
+      <!-- TODO: Add footer details -->
+    </footer>
+  </body>
+</html>

--- a/exercises/01-wireframe-to-web/styles.css
+++ b/exercises/01-wireframe-to-web/styles.css
@@ -1,0 +1,38 @@
+:root {
+  --space-xs: 0.5rem;
+  --space-sm: 1rem;
+  --space-md: 1.5rem;
+  --space-lg: 2.5rem;
+  --space-xl: 4rem;
+  --color-bg: #0b1220;
+  --color-surface: #111827;
+  --color-text: #f8fafc;
+  --color-muted: #94a3b8;
+  --radius: 1.25rem;
+  font-family: "Inter", system-ui, sans-serif;
+}
+
+body {
+  margin: 0;
+  background: linear-gradient(160deg, #0f172a, #1f2937);
+  color: var(--color-text);
+  min-height: 100vh;
+  padding: var(--space-lg) var(--space-sm) var(--space-xl);
+}
+
+main,
+header,
+footer {
+  background-color: rgba(17, 24, 39, 0.85);
+  padding: var(--space-md);
+  border-radius: var(--radius);
+  margin: 0 auto var(--space-md);
+  max-width: 60rem;
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.1);
+}
+
+section + section {
+  margin-top: var(--space-md);
+}
+
+/* TODO: Add layout styles at 48rem and 72rem breakpoints */

--- a/exercises/README.md
+++ b/exercises/README.md
@@ -1,0 +1,9 @@
+# Exercises
+
+Quick hits to reinforce the lessons. Each exercise includes:
+
+- A purpose statement so students know why they’re doing it.
+- Success criteria to keep grading transparent.
+- Optional remix ideas for students who finish early or want to go deeper.
+
+Drop in a timer, put on a playlist, and let the room hum.

--- a/lessons/01-semantic-html/README.md
+++ b/lessons/01-semantic-html/README.md
@@ -1,0 +1,36 @@
+# Lesson 01 · Semantic HTML Foundations
+
+## Why this matters
+Semantic HTML is the skeleton of every accessible, adaptable web page. We’re ditching meaningless `<div>` soup and building pages that screen readers and future collaborators can actually understand.
+
+## Learning objectives
+- Identify common semantic tags (`<header>`, `<nav>`, `<main>`, `<section>`, `<article>`, `<footer>`).
+- Build a simple multi-section page with meaningful hierarchy.
+- Pair headings and copy so content structure makes sense at a glance.
+
+## Session flow (45 min)
+1. **Hook (5 min):** Compare a semantic page vs. a div-only page. Ask students which one they’d rather maintain in a year.
+2. **Live build (20 min):** Walk through the included `index.html` to show structure and intent.
+3. **Guided remix (15 min):** Students replace the placeholder text with content from their own interests or another class.
+4. **Share-out (5 min):** Invite a few people to narrate their structure and why it helps future readers.
+
+## Vocabulary spotlight
+- **Semantic element:** Tags that tell both humans and browsers what type of content they wrap.
+- **Document outline:** The heading hierarchy that keeps content legible.
+- **Accessibility tree:** The assistive-tech-facing structure generated from semantic markup.
+
+## Stretch moves
+- Add a `<figure>` and `<figcaption>` for an image that matters to the story.
+- Build a nested `<article>` inside a `<section>` to simulate a news site or blog roll.
+- Validate the markup via [W3C Validator](https://validator.w3.org/) and fix any warnings.
+
+## Safety nets
+- Provide the `starter.html` file (a bare structure) if anyone gets stuck copying tags.
+- Encourage pair-programming: one student drives, the other navigates using the README as a checklist.
+
+## Files in this lesson
+- `index.html` — finished demo ready to present or dissect.
+- `starter.html` — empty structure for students who want to build from scratch.
+- `styles.css` — minimal aesthetics so the focus stays on structure.
+
+Clone this folder for assessments or retakes. Rename it, rewrite the README with new objectives, and ship it.

--- a/lessons/01-semantic-html/index.html
+++ b/lessons/01-semantic-html/index.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Community Radio Zine</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <h1>Community Radio Zine</h1>
+      <p class="tagline">Amplifying neighborhood voices since 2012.</p>
+      <nav aria-label="Primary navigation">
+        <ul class="nav-links">
+          <li><a href="#news">News</a></li>
+          <li><a href="#playlists">Playlists</a></li>
+          <li><a href="#events">Events</a></li>
+          <li><a href="#support">Support</a></li>
+        </ul>
+      </nav>
+    </header>
+
+    <main>
+      <section id="news" aria-labelledby="news-heading">
+        <header>
+          <h2 id="news-heading">Station News</h2>
+          <p class="section-lede">Catch up on what our volunteer DJs and producers are scheming.</p>
+        </header>
+
+        <article>
+          <h3>Work-in-progress recording booth</h3>
+          <p>
+            Volunteers are rebuilding Studio B with recycled materials and a lot of elbow grease. We’re documenting the process so
+            future cohorts can replicate the design on a budget.
+          </p>
+          <footer>
+            <p class="meta">Filed by <span class="author">Micah</span> on <time datetime="2024-03-12">March 12, 2024</time>.</p>
+          </footer>
+        </article>
+
+        <article>
+          <h3>Accessibility audit sprint</h3>
+          <p>
+            Our digital team ran an accessibility audit on the station website and prioritized issues with the most impact on screen
+            reader users. Students are invited to join the next audit to learn the workflow.
+          </p>
+          <footer>
+            <p class="meta">Filed by <span class="author">Rowan</span> on <time datetime="2024-02-27">February 27, 2024</time>.</p>
+          </footer>
+        </article>
+      </section>
+
+      <section id="playlists" aria-labelledby="playlists-heading">
+        <h2 id="playlists-heading">Featured Playlists</h2>
+        <p class="section-lede">Curated sets from last week’s open deck night.</p>
+        <ul class="playlist-grid">
+          <li>
+            <article>
+              <h3>Electric Evening</h3>
+              <p>Downtempo synths and ambient textures to wind down studio hours.</p>
+            </article>
+          </li>
+          <li>
+            <article>
+              <h3>Local Legends</h3>
+              <p>A lovingly noisy tribute to the Minneapolis punk scene.</p>
+            </article>
+          </li>
+          <li>
+            <article>
+              <h3>Morning Commute Mix</h3>
+              <p>Bite-sized interviews spliced with drum loops recorded on the light rail.</p>
+            </article>
+          </li>
+        </ul>
+      </section>
+
+      <section id="events" aria-labelledby="events-heading">
+        <h2 id="events-heading">Pop-up Events</h2>
+        <p class="section-lede">Drop in, bring friends, and maybe a soldering iron.</p>
+        <ul class="event-list">
+          <li>
+            <h3>Field Recording Walk</h3>
+            <p>Meet at the station and capture neighborhood ambience for the archives.</p>
+          </li>
+          <li>
+            <h3>Poster Printing Jam</h3>
+            <p>Silkscreen new show posters while learning layout hierarchy.</p>
+          </li>
+        </ul>
+      </section>
+    </main>
+
+    <footer id="support" class="site-footer">
+      <h2>Support the Station</h2>
+      <p>Donate gear, volunteer your time, or pitch a show idea. This station thrives on community care.</p>
+      <address>
+        <p>Email <a href="mailto:studio@crz.fm">studio@crz.fm</a></p>
+        <p>Visit us at 1157 Riverside Ave, Minneapolis, MN</p>
+      </address>
+    </footer>
+  </body>
+</html>

--- a/lessons/01-semantic-html/starter.html
+++ b/lessons/01-semantic-html/starter.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Semantic HTML Starter</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header>
+      <h1><!-- Page title goes here --></h1>
+      <p><!-- Tagline or summary --></p>
+      <nav aria-label="Primary navigation">
+        <ul>
+          <li><a href="#section-1">Section 1</a></li>
+          <li><a href="#section-2">Section 2</a></li>
+          <li><a href="#section-3">Section 3</a></li>
+        </ul>
+      </nav>
+    </header>
+
+    <main>
+      <section id="section-1" aria-labelledby="section-1-heading">
+        <h2 id="section-1-heading"><!-- Heading --></h2>
+        <article>
+          <h3><!-- Article heading --></h3>
+          <p><!-- Content --></p>
+          <footer>
+            <p><!-- Meta info like author + date --></p>
+          </footer>
+        </article>
+      </section>
+
+      <section id="section-2" aria-labelledby="section-2-heading">
+        <h2 id="section-2-heading"><!-- Heading --></h2>
+        <p><!-- Supporting copy --></p>
+      </section>
+
+      <section id="section-3" aria-labelledby="section-3-heading">
+        <h2 id="section-3-heading"><!-- Heading --></h2>
+        <ul>
+          <li><!-- List item --></li>
+          <li><!-- List item --></li>
+        </ul>
+      </section>
+    </main>
+
+    <footer>
+      <h2><!-- Call-to-action heading --></h2>
+      <address>
+        <p><!-- Contact info --></p>
+      </address>
+    </footer>
+  </body>
+</html>

--- a/lessons/01-semantic-html/styles.css
+++ b/lessons/01-semantic-html/styles.css
@@ -1,0 +1,122 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  line-height: 1.6;
+  background-color: #0f172a;
+  color: #f8fafc;
+}
+
+body {
+  margin: 0 auto;
+  padding: 2rem 1.5rem 4rem;
+  max-width: 60rem;
+}
+
+.site-header,
+.site-footer {
+  text-align: center;
+  background: linear-gradient(135deg, #0ea5e9, #6366f1);
+  padding: 2.5rem 2rem;
+  margin-bottom: 2rem;
+  border-radius: 1.25rem;
+  box-shadow: 0 1.5rem 3rem rgba(15, 23, 42, 0.35);
+}
+
+.site-header h1 {
+  margin-bottom: 0.25rem;
+  font-size: clamp(2.5rem, 4vw, 3.5rem);
+}
+
+.tagline {
+  font-size: 1.125rem;
+  margin-bottom: 1.5rem;
+}
+
+.nav-links {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.nav-links a {
+  color: inherit;
+  text-decoration: none;
+  font-weight: 600;
+  padding: 0.4rem 0.75rem;
+  border-radius: 999px;
+  transition: background-color 0.2s ease;
+}
+
+.nav-links a:focus,
+.nav-links a:hover {
+  background-color: rgba(15, 23, 42, 0.2);
+}
+
+main {
+  display: grid;
+  gap: 2rem;
+}
+
+section {
+  background: rgba(15, 23, 42, 0.55);
+  padding: 2rem;
+  border-radius: 1.25rem;
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.2);
+}
+
+section h2 {
+  margin-top: 0;
+  font-size: clamp(2rem, 3vw, 2.5rem);
+}
+
+.section-lede {
+  color: #cbd5f5;
+  margin-bottom: 1.25rem;
+}
+
+article {
+  background: rgba(15, 23, 42, 0.35);
+  padding: 1.25rem;
+  border-radius: 1rem;
+  margin-bottom: 1rem;
+  box-shadow: inset 0 0 0 1px rgba(99, 102, 241, 0.35);
+}
+
+article h3 {
+  margin-top: 0;
+  font-size: 1.25rem;
+}
+
+.meta {
+  font-size: 0.875rem;
+  color: #94a3b8;
+}
+
+.playlist-grid {
+  list-style: none;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+}
+
+.event-list {
+  list-style: square;
+  padding-left: 1.5rem;
+}
+
+a {
+  color: #38bdf8;
+}
+
+a:focus,
+a:hover {
+  color: #f472b6;
+}
+
+address {
+  font-style: normal;
+}

--- a/lessons/02-responsive-layout/README.md
+++ b/lessons/02-responsive-layout/README.md
@@ -1,0 +1,38 @@
+# Lesson 02 · Responsive Layout Remix
+
+## Why this matters
+Students need to see how a single HTML document can flex from phone to widescreen without breaking. This lesson shows off mobile-first CSS with Flexbox and Grid so they build layouts that respect any viewport.
+
+## Learning objectives
+- Interpret wireframes for small, medium, and large breakpoints.
+- Use modern CSS layout tools (Flexbox and Grid) to rearrange content responsively.
+- Apply custom properties to keep spacing and color tokens consistent.
+
+## Session flow (50 min)
+1. **Warm-up critique (5 min):** Show a site that collapses poorly on mobile. Ask students to identify the pain points.
+2. **Code walk (15 min):** Step through the mobile-first CSS in `styles.css` and inspect the live results.
+3. **Breakpoint challenge (20 min):** Students implement one additional breakpoint using the provided comments as guides.
+4. **Reflection (10 min):** Discuss how the layout scales and how design decisions shifted per breakpoint.
+
+## Vocabulary spotlight
+- **Flex container / item**
+- **Grid template areas**
+- **Breakpoint**
+- **Intrinsic sizing**
+
+## Stretch moves
+- Swap the color theme via CSS custom properties.
+- Add a `prefers-reduced-motion` media query to tame animations.
+- Replace one image card with a `<figure>` + `<figcaption>` combination.
+
+## Safety nets
+- Students can fall back to the `one-column` utility class if they get lost.
+- Encourage using browser DevTools device toolbar to visualize breakpoints.
+- Remind them to save often and refresh — caching bites everyone eventually.
+
+## Files in this lesson
+- `index.html` — mobile-first markup with labeled regions.
+- `styles.css` — annotated CSS that layers on complexity with media queries.
+- `wireframe.svg` — reference diagram for the three breakpoints (print it or project it).
+
+Use this lesson as a blueprint for future layout labs. Copy the pattern, change the story, keep the rhythm.

--- a/lessons/02-responsive-layout/index.html
+++ b/lessons/02-responsive-layout/index.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Neighborhood Makerspace</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <p class="eyebrow">Lesson 02 Demo</p>
+      <h1>Neighborhood Makerspace</h1>
+      <p class="lede">
+        Follow the layout comments to see how a single HTML document can bend from mobile to desktop without losing its soul.
+      </p>
+      <button class="cta">Become a Member</button>
+    </header>
+
+    <main class="layout">
+      <section class="about" aria-labelledby="about-heading">
+        <h2 id="about-heading">What we do</h2>
+        <p>
+          We operate a community-powered makerspace focused on ethical tech, radical printmaking, and joyful repair. Our workshops
+          pair art-school experimentation with neighborhood needs.
+        </p>
+      </section>
+
+      <section class="events" aria-labelledby="events-heading">
+        <h2 id="events-heading">Upcoming workshops</h2>
+        <ul class="event-list">
+          <li>
+            <h3>Intro to Soldering</h3>
+            <p>Learn to repair audio gear and synth modules while blasting local bands.</p>
+            <time datetime="2024-04-04">April 4</time>
+          </li>
+          <li>
+            <h3>Risograph Poster Lab</h3>
+            <p>Design for two-color riso prints and walk out with a stack of radical posters.</p>
+            <time datetime="2024-04-18">April 18</time>
+          </li>
+          <li>
+            <h3>Mutual Aid Dev Sprint</h3>
+            <p>Spin up a microsite for a local org. Bring HTML/CSS/JS and a willingness to collaborate.</p>
+            <time datetime="2024-05-01">May 1</time>
+          </li>
+        </ul>
+      </section>
+
+      <section class="gallery" aria-labelledby="gallery-heading">
+        <h2 id="gallery-heading">Space vibes</h2>
+        <div class="card">
+          <img src="https://images.unsplash.com/photo-1526498460520-4c246339dccb?auto=format&fit=crop&w=600&q=80" alt="People collaborating around a table covered in electronics." />
+          <p>Night soldering session with the synth collective.</p>
+        </div>
+        <div class="card">
+          <img src="https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=600&q=80" alt="Bright risograph prints on a drying rack." />
+          <p>Fresh risograph prints curing on the rack.</p>
+        </div>
+        <div class="card">
+          <img src="https://images.unsplash.com/photo-1523475472560-d2df97ec485c?auto=format&fit=crop&w=600&q=80" alt="Laptop and notebook with code sketches." />
+          <p>Planning meeting for the mutual aid site redesign.</p>
+        </div>
+      </section>
+
+      <aside class="cta-panel" aria-label="Membership teaser">
+        <h2>Sliding scale memberships</h2>
+        <p>
+          Nobody gets turned away. Choose a membership level that works for your budget and time, or volunteer to offset the cost.
+        </p>
+        <a class="link-button" href="#">See membership tiers</a>
+      </aside>
+
+      <section class="testimonials" aria-labelledby="testimonials-heading">
+        <h2 id="testimonials-heading">Member voices</h2>
+        <blockquote>
+          “I came for the 3D printers, stayed for the community dinners.” — <cite>Kai (they/them)</cite>
+        </blockquote>
+        <blockquote>
+          “My students now run their own zine nights thanks to the print lab.” — <cite>Delilah (she/her)</cite>
+        </blockquote>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <p>© 2024 Neighborhood Makerspace Cooperative</p>
+    </footer>
+  </body>
+</html>

--- a/lessons/02-responsive-layout/styles.css
+++ b/lessons/02-responsive-layout/styles.css
@@ -1,0 +1,194 @@
+/*
+  This stylesheet is intentionally verbose so you can narrate every step.
+  Breakpoints: base (mobile), 48rem, 72rem.
+*/
+
+:root {
+  color-scheme: only light;
+  --space-xs: 0.5rem;
+  --space-sm: 1rem;
+  --space-md: 1.5rem;
+  --space-lg: 2.5rem;
+  --space-xl: 4rem;
+  --color-bg: #0f0f10;
+  --color-surface: #18181b;
+  --color-surface-alt: #27272a;
+  --color-text: #f4f4f5;
+  --color-accent: #f97316;
+  --radius-lg: 1.5rem;
+  font-family: "Atkinson Hyperlegible", system-ui, sans-serif;
+  line-height: 1.6;
+}
+
+body {
+  margin: 0;
+  background-color: var(--color-bg);
+  color: var(--color-text);
+}
+
+img {
+  max-width: 100%;
+  border-radius: 1rem;
+}
+
+.site-header {
+  padding: var(--space-xl) var(--space-sm) var(--space-lg);
+  text-align: center;
+  background: radial-gradient(circle at top, #1d1d20, var(--color-surface));
+  border-bottom: 1px solid rgba(244, 244, 245, 0.08);
+}
+
+.eyebrow {
+  font-size: 0.875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: rgba(244, 244, 245, 0.65);
+}
+
+h1 {
+  font-size: clamp(2.25rem, 5vw, 3.75rem);
+  margin-bottom: var(--space-sm);
+}
+
+.lede {
+  margin: 0 auto var(--space-md);
+  max-width: 45ch;
+  color: rgba(244, 244, 245, 0.75);
+}
+
+.cta {
+  border: none;
+  background: var(--color-accent);
+  color: #111;
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.cta:hover,
+.cta:focus {
+  transform: translateY(-2px);
+  box-shadow: 0 1rem 2.5rem rgba(249, 115, 22, 0.35);
+}
+
+.layout {
+  display: grid;
+  gap: var(--space-lg);
+  padding: var(--space-lg) var(--space-sm) var(--space-xl);
+}
+
+.layout > * {
+  background-color: var(--color-surface);
+  border-radius: var(--radius-lg);
+  padding: var(--space-md);
+  box-shadow: inset 0 0 0 1px rgba(244, 244, 245, 0.05);
+}
+
+.event-list,
+blockquote {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.event-list li + li {
+  margin-top: var(--space-sm);
+  border-top: 1px solid rgba(244, 244, 245, 0.08);
+  padding-top: var(--space-sm);
+}
+
+.card {
+  background-color: var(--color-surface-alt);
+  padding: var(--space-sm);
+  border-radius: calc(var(--radius-lg) - 0.5rem);
+}
+
+.card p {
+  margin: var(--space-xs) 0 0;
+  color: rgba(244, 244, 245, 0.65);
+}
+
+.link-button {
+  display: inline-block;
+  color: var(--color-text);
+  text-decoration: none;
+  background: linear-gradient(135deg, #f97316, #fb7185);
+  padding: 0.6rem 1.1rem;
+  border-radius: 0.8rem;
+  font-weight: 600;
+}
+
+blockquote {
+  font-size: 1.1rem;
+  background-color: var(--color-surface-alt);
+  padding: var(--space-sm);
+  border-left: 4px solid var(--color-accent);
+  border-radius: calc(var(--radius-lg) - 1rem);
+}
+
+.site-footer {
+  text-align: center;
+  padding: var(--space-lg) var(--space-sm);
+  color: rgba(244, 244, 245, 0.5);
+}
+
+/* ---------------------------------------------
+   Breakpoint @ 48rem: introduce two-column grid
+---------------------------------------------- */
+@media (min-width: 48rem) {
+  .layout {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .gallery {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: var(--space-sm);
+  }
+
+  .cta-panel {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+  }
+
+  .testimonials {
+    grid-column: span 2;
+  }
+}
+
+/* ---------------------------------------------
+   Breakpoint @ 72rem: use grid template areas
+---------------------------------------------- */
+@media (min-width: 72rem) {
+  .layout {
+    grid-template-columns: 2fr 1fr 1fr;
+    grid-template-areas:
+      "about about cta"
+      "events gallery cta"
+      "events gallery testimonials";
+  }
+
+  .about {
+    grid-area: about;
+  }
+
+  .events {
+    grid-area: events;
+  }
+
+  .gallery {
+    grid-area: gallery;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .cta-panel {
+    grid-area: cta;
+  }
+
+  .testimonials {
+    grid-area: testimonials;
+  }
+}

--- a/lessons/02-responsive-layout/wireframe.svg
+++ b/lessons/02-responsive-layout/wireframe.svg
@@ -1,0 +1,53 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 600" aria-labelledby="title desc" role="img">
+  <title id="title">Responsive layout wireframe</title>
+  <desc id="desc">Three breakpoints showing how sections rearrange from stacked to grid layout.</desc>
+  <style>
+    .panel { fill: #18181b; stroke: #f97316; stroke-width: 6; rx: 24; ry: 24; }
+    .label { fill: #f4f4f5; font-family: 'Inter', sans-serif; font-size: 36px; text-anchor: middle; }
+    .caption { fill: #a1a1aa; font-family: 'Inter', sans-serif; font-size: 28px; text-anchor: middle; }
+  </style>
+
+  <!-- Mobile stack -->
+  <rect class="panel" x="40" y="40" width="320" height="520" />
+  <text class="caption" x="200" y="90">Mobile</text>
+  <rect class="panel" x="70" y="120" width="260" height="80" />
+  <text class="label" x="200" y="170">Header</text>
+  <rect class="panel" x="70" y="220" width="260" height="120" />
+  <text class="label" x="200" y="280">About</text>
+  <rect class="panel" x="70" y="360" width="260" height="120" />
+  <text class="label" x="200" y="420">Events</text>
+  <rect class="panel" x="70" y="500" width="260" height="60" />
+  <text class="label" x="200" y="540">Footer</text>
+
+  <!-- Tablet grid -->
+  <rect class="panel" x="440" y="40" width="320" height="520" />
+  <text class="caption" x="600" y="90">Tablet (48rem)</text>
+  <rect class="panel" x="470" y="120" width="260" height="80" />
+  <text class="label" x="600" y="170">Header</text>
+  <rect class="panel" x="470" y="220" width="120" height="240" />
+  <text class="label" x="530" y="340" transform="rotate(-90 530 340)">Events</text>
+  <rect class="panel" x="610" y="220" width="120" height="120" />
+  <text class="label" x="670" y="280">Gallery</text>
+  <rect class="panel" x="610" y="360" width="120" height="100" />
+  <text class="label" x="670" y="410">CTA</text>
+  <rect class="panel" x="470" y="470" width="260" height="70" />
+  <text class="label" x="600" y="515">Footer</text>
+
+  <!-- Desktop grid -->
+  <rect class="panel" x="840" y="40" width="320" height="520" />
+  <text class="caption" x="1000" y="90">Desktop (72rem+)</text>
+  <rect class="panel" x="870" y="120" width="260" height="80" />
+  <text class="label" x="1000" y="170">Header</text>
+  <rect class="panel" x="870" y="220" width="160" height="150" />
+  <text class="label" x="950" y="285">About</text>
+  <rect class="panel" x="870" y="380" width="160" height="120" />
+  <text class="label" x="950" y="440">Events</text>
+  <rect class="panel" x="870" y="340" width="160" height="30" />
+  <text class="label" x="950" y="360">Gallery</text>
+  <rect class="panel" x="1040" y="220" width="90" height="220" />
+  <text class="label" x="1085" y="330" transform="rotate(-90 1085 330)">CTA</text>
+  <rect class="panel" x="870" y="510" width="260" height="70" />
+  <text class="label" x="1000" y="555">Footer</text>
+  <rect class="panel" x="870" y="470" width="160" height="30" />
+  <text class="label" x="950" y="490">Testimonials</text>
+</svg>

--- a/lessons/03-dom-interactions/README.md
+++ b/lessons/03-dom-interactions/README.md
@@ -1,0 +1,39 @@
+# Lesson 03 · DOM Interactions Without the Drama
+
+## Why this matters
+JavaScript gets loud fast. This lesson focuses on small, meaningful DOM interactions: toggling a modal, filtering content, and making sure it all remains accessible. Students practice event listeners, state, and progressive enhancement.
+
+## Learning objectives
+- Wire up event listeners using `addEventListener` and named handler functions.
+- Manipulate classes and ARIA attributes to reflect UI state changes.
+- Iterate over a list of elements to filter content based on user input.
+
+## Session flow (55 min)
+1. **Showcase (5 min):** Trigger the modal + filter in the finished demo. Ask students to narrate what they observe.
+2. **HTML/ARIA tour (10 min):** Highlight the baseline markup and why the page works even without JavaScript.
+3. **JS pair-programming (25 min):** Build the interactions step by step following `script.js` comments.
+4. **Debug jam (10 min):** Introduce a bug (e.g., wrong selector) and have teams fix it together.
+5. **Wrap-up (5 min):** Summarize the event flow and emphasize cleanup (removing listeners if needed).
+
+## Vocabulary spotlight
+- **Progressive enhancement**
+- **ARIA expanded / hidden**
+- **NodeList vs. Array**
+- **State toggle**
+
+## Stretch moves
+- Animate the modal entrance with CSS transitions tied to `.is-open`.
+- Swap the filter logic to search by dataset tags instead of text content.
+- Add keyboard shortcuts for opening/closing the modal.
+
+## Safety nets
+- All state changes rely on toggling the `.is-open` class. Resetting the class list fixes most issues.
+- The modal button includes `data-modal-target` for easy reference if selectors go sideways.
+- Comments in `script.js` outline the order of operations for each interaction.
+
+## Files in this lesson
+- `index.html` — accessible baseline markup with enhancements layered on.
+- `styles.css` — focus on clarity, not glitter, but includes CSS variables ready for theming.
+- `script.js` — fully commented, with optional challenges flagged in the file.
+
+This is a perfect setup for code-along or lab-day pacing. Remix the content theme and keep the interaction scaffolding.

--- a/lessons/03-dom-interactions/index.html
+++ b/lessons/03-dom-interactions/index.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Workshop Directory · Lesson 03</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <h1>Workshop Directory</h1>
+      <p class="lede">
+        Built for Lesson 03 of ART215. Works without JavaScript, then levels up with accessible interactions once the script loads.
+      </p>
+      <button class="open-modal" data-modal-target="proposal-modal" aria-haspopup="dialog" aria-controls="proposal-modal">
+        Pitch a Workshop
+      </button>
+    </header>
+
+    <main class="layout" id="main-content">
+      <section aria-labelledby="filter-heading" class="filters">
+        <h2 id="filter-heading">Filter by vibe</h2>
+        <p>Start typing to highlight the workshops that match your mood.</p>
+        <label class="filter-label" for="filter-input">Search workshops</label>
+        <input id="filter-input" name="filter" type="search" placeholder="e.g. print, audio, code" />
+      </section>
+
+      <section aria-labelledby="workshop-heading" class="workshop-list">
+        <h2 id="workshop-heading">Upcoming sessions</h2>
+        <ul class="cards" data-filter-target>
+          <li class="card" data-tags="print typography community">
+            <h3>Collaborative Zine Sprint</h3>
+            <p>Create a zine from scratch with strangers. Layout tips included.</p>
+            <p class="meta">Facilitator: Jules · Level: Beginner friendly</p>
+          </li>
+          <li class="card" data-tags="audio electronics repair">
+            <h3>Synth Repair Clinic</h3>
+            <p>Diagnose and revive analog synths using modular troubleshooting flows.</p>
+            <p class="meta">Facilitator: Mina · Level: Intermediate</p>
+          </li>
+          <li class="card" data-tags="code accessibility web">
+            <h3>Access-First Web Sprint</h3>
+            <p>Audit and refactor community websites with an accessibility-first mindset.</p>
+            <p class="meta">Facilitator: Jordan · Level: All welcome</p>
+          </li>
+          <li class="card" data-tags="audio storytelling community">
+            <h3>Oral History Recording Lab</h3>
+            <p>Capture neighborhood stories with portable audio gear and ethical consent practices.</p>
+            <p class="meta">Facilitator: Zahra · Level: Beginner</p>
+          </li>
+          <li class="card" data-tags="code data visualization">
+            <h3>Mutual Aid Dashboard Hack</h3>
+            <p>Prototype data visualizations that keep resource distribution transparent.</p>
+            <p class="meta">Facilitator: Diego · Level: Intermediate</p>
+          </li>
+        </ul>
+      </section>
+    </main>
+
+    <dialog id="proposal-modal" class="modal" aria-labelledby="modal-title">
+      <form method="dialog" class="modal-content">
+        <header>
+          <h2 id="modal-title">Pitch your workshop</h2>
+          <button type="button" class="close-modal" aria-label="Close proposal form">×</button>
+        </header>
+        <p>Use this form to propose a new session. Keep it weird, keep it kind.</p>
+        <label for="proposal-title">Workshop title</label>
+        <input id="proposal-title" name="title" type="text" required />
+        <label for="proposal-focus">What will folks learn?</label>
+        <textarea id="proposal-focus" name="focus" rows="4" required></textarea>
+        <menu class="modal-actions">
+          <button type="reset">Reset</button>
+          <button type="submit">Send it</button>
+        </menu>
+      </form>
+    </dialog>
+
+    <script src="script.js" defer></script>
+  </body>
+</html>

--- a/lessons/03-dom-interactions/script.js
+++ b/lessons/03-dom-interactions/script.js
@@ -1,0 +1,121 @@
+// Lesson 03 interaction script
+// The goal: demonstrate how a few well-structured functions can power a modal + filter without a framework.
+
+const filterInput = document.querySelector('#filter-input');
+const filterTarget = document.querySelector('[data-filter-target]');
+const modal = document.querySelector('#proposal-modal');
+const openModalButton = document.querySelector('.open-modal');
+const closeModalButton = modal?.querySelector('.close-modal');
+
+// Guard clause: bail if essential elements are missing (progressive enhancement!)
+if (!filterInput || !filterTarget || !modal || !openModalButton || !closeModalButton) {
+  console.warn('Lesson 03 script: required elements missing. Check the markup.');
+} else {
+  const workshopCards = Array.from(filterTarget.querySelectorAll('.card'));
+
+  /**
+   * filterWorkshops
+   * Highlights workshops that match the query and hides the rest when the query is non-empty.
+   */
+  function filterWorkshops(event) {
+    const query = event.target.value.trim().toLowerCase();
+
+    workshopCards.forEach((card) => {
+      const textContent = `${card.textContent} ${card.dataset.tags}`.toLowerCase();
+      const matches = query.length === 0 || textContent.includes(query);
+
+      card.toggleAttribute('hidden', query.length > 0 && !matches);
+      card.classList.toggle('is-highlighted', matches && query.length > 0);
+    });
+  }
+
+  /**
+   * openModal + closeModal manage the <dialog> element and sync ARIA state.
+   */
+  function openModal() {
+    modal.showModal();
+    modal.classList.add('is-open');
+    openModalButton.setAttribute('aria-expanded', 'true');
+    trapFocus(modal);
+  }
+
+  function closeModal() {
+    modal.close();
+    modal.classList.remove('is-open');
+    openModalButton.setAttribute('aria-expanded', 'false');
+    releaseFocusTrap();
+  }
+
+  // Bind listeners
+  filterInput.addEventListener('input', filterWorkshops);
+  openModalButton.addEventListener('click', openModal);
+  closeModalButton.addEventListener('click', closeModal);
+  modal.addEventListener('cancel', (event) => {
+    event.preventDefault();
+    closeModal();
+  });
+
+  modal.addEventListener('click', (event) => {
+    const dialogRect = modal.getBoundingClientRect();
+    const clickInside =
+      event.clientX >= dialogRect.left &&
+      event.clientX <= dialogRect.right &&
+      event.clientY >= dialogRect.top &&
+      event.clientY <= dialogRect.bottom;
+
+    if (!clickInside) {
+      closeModal();
+    }
+  });
+
+  // Accessibility bonus: basic focus trap while the dialog is open.
+  let previousActiveElement = null;
+
+  function trapFocus(dialog) {
+    previousActiveElement = document.activeElement;
+    const focusableSelectors = [
+      'button',
+      'a[href]',
+      'input',
+      'textarea',
+      '[tabindex]:not([tabindex="-1"])'
+    ];
+    const focusables = dialog.querySelectorAll(focusableSelectors.join(','));
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+
+    dialog.addEventListener('keydown', handleKeydown);
+    if (first) {
+      first.focus();
+    }
+
+    function handleKeydown(event) {
+      if (event.key === 'Tab') {
+        if (event.shiftKey && document.activeElement === first) {
+          event.preventDefault();
+          last?.focus();
+        } else if (!event.shiftKey && document.activeElement === last) {
+          event.preventDefault();
+          first?.focus();
+        }
+      }
+
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        closeModal();
+      }
+    }
+
+    // Store handler so we can remove it later
+    dialog._focusTrapHandler = handleKeydown;
+  }
+
+  function releaseFocusTrap() {
+    if (modal._focusTrapHandler) {
+      modal.removeEventListener('keydown', modal._focusTrapHandler);
+      modal._focusTrapHandler = null;
+    }
+
+    previousActiveElement?.focus();
+  }
+}

--- a/lessons/03-dom-interactions/styles.css
+++ b/lessons/03-dom-interactions/styles.css
@@ -1,0 +1,179 @@
+:root {
+  color-scheme: dark light;
+  --bg: #0b1120;
+  --surface: #111827;
+  --surface-alt: #1f2937;
+  --text: #f9fafb;
+  --muted: #94a3b8;
+  --accent: #f59e0b;
+  --danger: #fb7185;
+  font-family: "IBM Plex Sans", system-ui, sans-serif;
+  line-height: 1.6;
+}
+
+body {
+  margin: 0;
+  background: radial-gradient(circle at top, #1f2937, var(--bg));
+  color: var(--text);
+  min-height: 100vh;
+}
+
+.site-header {
+  padding: 3.5rem 1.5rem 2.5rem;
+  text-align: center;
+}
+
+.lede {
+  max-width: 52ch;
+  margin: 0.75rem auto 1.5rem;
+  color: var(--muted);
+}
+
+.open-modal {
+  background: var(--accent);
+  color: #111;
+  border: none;
+  padding: 0.75rem 1.75rem;
+  border-radius: 999px;
+  font-weight: 700;
+  cursor: pointer;
+  box-shadow: 0 1.25rem 2.5rem rgba(245, 158, 11, 0.35);
+}
+
+.layout {
+  display: grid;
+  gap: 2rem;
+  padding: 0 1.5rem 3rem;
+  max-width: 70rem;
+  margin: 0 auto;
+}
+
+.layout > section {
+  background: rgba(17, 24, 39, 0.75);
+  padding: 1.75rem;
+  border-radius: 1.25rem;
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.1);
+}
+
+.filters input {
+  width: 100%;
+  margin-top: 0.5rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background-color: var(--surface);
+  color: inherit;
+}
+
+.cards {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.card {
+  padding: 1.25rem;
+  border-radius: 1rem;
+  background: var(--surface-alt);
+  border: 1px solid rgba(15, 118, 110, 0.15);
+  transition: transform 0.2s ease, border-color 0.2s ease;
+}
+
+.card[hidden] {
+  display: none;
+}
+
+.card.is-highlighted {
+  border-color: var(--accent);
+  transform: translateY(-4px);
+}
+
+.meta {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.modal {
+  width: min(90vw, 32rem);
+  border: none;
+  border-radius: 1.5rem;
+  background: rgba(15, 23, 42, 0.95);
+  color: var(--text);
+  padding: 0;
+  box-shadow: 0 1.5rem 3rem rgba(15, 23, 42, 0.6);
+}
+
+.modal::backdrop {
+  background: rgba(8, 11, 19, 0.75);
+}
+
+.modal-content {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 2rem;
+}
+
+.modal-content header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.close-modal {
+  border: none;
+  background: transparent;
+  color: var(--text);
+  font-size: 1.75rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.modal-content label {
+  display: block;
+  font-weight: 600;
+}
+
+.modal-content input,
+.modal-content textarea {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background-color: rgba(30, 41, 59, 0.9);
+  color: inherit;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.modal-actions button[type="submit"] {
+  background: var(--accent);
+  border: none;
+  padding: 0.6rem 1.5rem;
+  border-radius: 999px;
+  font-weight: 700;
+}
+
+.modal-actions button[type="reset"] {
+  background: transparent;
+  color: var(--muted);
+  border: 1px dashed rgba(148, 163, 184, 0.4);
+  border-radius: 999px;
+  padding: 0.6rem 1.5rem;
+}
+
+@media (min-width: 56rem) {
+  .layout {
+    grid-template-columns: 1fr 2fr;
+  }
+
+  .workshop-list {
+    grid-column: span 1;
+  }
+}

--- a/lessons/README.md
+++ b/lessons/README.md
@@ -1,0 +1,9 @@
+# Lessons
+
+Each lesson is a fully-scripted walkthrough designed for a 30–45 minute session. You get:
+
+- A punky, plain-language README with objectives, vocabulary, and pacing hints.
+- Ready-to-run demo files (`index.html`, `styles.css`, and sometimes `script.js`).
+- Stretch goals so advanced students can keep rolling while you coach folks who need more time.
+
+Teach them in sequence or mix them up depending on the energy in the room.

--- a/projects/README.md
+++ b/projects/README.md
@@ -1,0 +1,9 @@
+# Projects
+
+Longer builds meant for multi-week arcs or capstone energy. Each project starter includes:
+
+- A narrative prompt to get students emotionally invested.
+- Milestones to break the work into critique-ready chunks.
+- Rubric-friendly success metrics plus optional community-facing deliverables.
+
+Feel free to fork, remix, and merge back your best iterations.

--- a/projects/portfolio-microsite/README.md
+++ b/projects/portfolio-microsite/README.md
@@ -1,0 +1,38 @@
+# Project · Portfolio Microsite Remix
+
+## Intent
+Students craft a one-page portfolio microsite for a creative they admire (artist, designer, organizer, musician). The goal is to apply lessons from semantic HTML, responsive layout, and DOM interactions while telling someone else’s story with respect and flair.
+
+## Timeline (2–3 weeks)
+1. **Week 1 — Discovery & IA:** Research the subject, outline content, sketch wireframes (mobile + desktop).
+2. **Week 2 — Build & iterate:** Implement structure and layout, gather peer feedback, refine typography and imagery.
+3. **Week 3 — Interaction polish:** Layer in subtle DOM interactions (modal, filter, accordion) and prep for public launch.
+
+## Deliverables
+- **Content strategy doc (`content-plan.md`):** Audience, tone, narrative arc, and accessibility considerations.
+- **Live site (`index.html` + assets):** Fully responsive, accessible, and performant.
+- **Retrospective (`retro.md`):** What worked, what broke, what you’d try differently next time.
+
+## Success metrics
+- Semantic structure passes an accessibility tree spot-check (use screen reader or DevTools).
+- Layout adapts to at least three breakpoints, with intentional typographic scale shifts.
+- At least one progressive enhancement interaction that still leaves the content usable without JS.
+- Git history shows regular commits with descriptive messages.
+
+## Stretch challenges
+- Integrate a simple CMS-like workflow (e.g., JSON data file + templating via Eleventy/Vite).
+- Add localization support for two languages and note copy considerations in `content-plan.md`.
+- Implement automated testing (Lighthouse CI, axe-core) and include results in the retrospective.
+
+## Critique prompts
+- How does the visual language honor the subject’s work without mimicking it?
+- Where do interaction patterns enhance storytelling vs. distract from it?
+- How would the site scale into a multi-page experience?
+
+## Starter files
+- `content-plan.md` — fill in with research notes and planned sections.
+- `index.html` — baseline structure to customize.
+- `styles.css` — CSS tokens and layout scaffolding ready for tweaking.
+- `script.js` — optional interactive hooks (accordion + modal placeholders).
+
+Run critiques at the end of each week. Encourage students to celebrate the messy middle, not just the polished deliverable.

--- a/projects/portfolio-microsite/content-plan.md
+++ b/projects/portfolio-microsite/content-plan.md
@@ -1,0 +1,32 @@
+# Portfolio Microsite · Content Plan Template
+
+## Subject snapshot
+- **Name:**
+- **Discipline(s):**
+- **Community / location:**
+- **One-sentence sparkline:**
+
+## Audience + goals
+- Primary audience(s):
+- What should they feel/know/do after visiting the site?
+- Accessibility considerations to center from the start:
+
+## Narrative outline
+1. Hero section focus:
+2. Supporting section 1 (e.g., featured work):
+3. Supporting section 2 (e.g., process, manifesto):
+4. Interaction hook (e.g., modal interview, filterable gallery):
+5. Call to action (e.g., support, attend, collaborate):
+
+## Voice + tone notes
+- Keywords for copy tone:
+- Words/phrases to avoid:
+- How to honor the subject’s own voice:
+
+## Asset checklist
+- Images/photos needed (with alt text drafts):
+- Audio/video embeds needed (with transcript/summary plan):
+- External links + descriptions:
+
+## Research notes
+Drop quotes, references, and inspiration links here so you can cite sources later.

--- a/projects/portfolio-microsite/index.html
+++ b/projects/portfolio-microsite/index.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Portfolio Microsite Starter</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="site-header" id="top">
+      <nav class="skip-links" aria-label="Skip links">
+        <a href="#main-content">Skip to content</a>
+      </nav>
+      <div class="hero">
+        <p class="eyebrow">Portfolio microsite starter</p>
+        <h1>Subject Name Here</h1>
+        <p class="lede">
+          Replace this text with a bold, respectful introduction to your subject. Keep it concise and hook visitors immediately.
+        </p>
+        <div class="actions">
+          <a class="button" href="#featured-work">See featured work</a>
+          <button class="ghost" data-modal-target="contact-modal">Contact / Support</button>
+        </div>
+      </div>
+      <ul class="meta">
+        <li><strong>Discipline:</strong> <span data-field="discipline">Interdisciplinary</span></li>
+        <li><strong>Location:</strong> <span data-field="location">Twin Cities, MN</span></li>
+        <li><strong>Latest project:</strong> <span data-field="project">Community soundscape</span></li>
+      </ul>
+    </header>
+
+    <main id="main-content" class="layout">
+      <section id="featured-work" aria-labelledby="featured-heading">
+        <header>
+          <h2 id="featured-heading">Featured work</h2>
+          <p>Swap in case studies or artifacts. Each `<article>` can include media, description, and links.</p>
+        </header>
+        <div class="cards">
+          <article>
+            <h3>Project One</h3>
+            <p class="summary">Describe the project, collaborators, and impact.</p>
+            <a href="#" class="text-link">View case study</a>
+          </article>
+          <article>
+            <h3>Project Two</h3>
+            <p class="summary">Highlight the challenge, process, and outcome.</p>
+            <a href="#" class="text-link">View case study</a>
+          </article>
+          <article>
+            <h3>Project Three</h3>
+            <p class="summary">Call out metrics or testimonials that prove the value.</p>
+            <a href="#" class="text-link">View case study</a>
+          </article>
+        </div>
+      </section>
+
+      <section id="process" aria-labelledby="process-heading">
+        <h2 id="process-heading">Process &amp; practice</h2>
+        <p>
+          Use this space for a manifesto, artist statement, or behind-the-scenes glimpse. Consider layering in pull quotes or a
+          small accordion for frequently asked questions.
+        </p>
+        <div class="accordion" data-accordion>
+          <button class="accordion-toggle" aria-expanded="false">
+            <span>FAQ: How do collaborations work?</span>
+          </button>
+          <div class="accordion-panel" hidden>
+            <p>
+              Replace this with your subject’s answer. Remember to note contact preferences and boundaries if relevant.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section id="timeline" aria-labelledby="timeline-heading">
+        <h2 id="timeline-heading">Milestones</h2>
+        <ol class="timeline">
+          <li>
+            <time datetime="2020">2020</time>
+            <p>Milestone description — maybe a residency, award, or community project.</p>
+          </li>
+          <li>
+            <time datetime="2022">2022</time>
+            <p>Another milestone. Swap in details that build narrative momentum.</p>
+          </li>
+          <li>
+            <time datetime="2024">2024</time>
+            <p>Most recent highlight or current work-in-progress.</p>
+          </li>
+        </ol>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <p>© <span data-field="year">2024</span> Subject Name. Built with care by [Your Name].</p>
+      <a href="#top" class="text-link">Back to top</a>
+    </footer>
+
+    <dialog id="contact-modal" class="modal" aria-labelledby="modal-heading">
+      <form method="dialog" class="modal-content">
+        <header>
+          <h2 id="modal-heading">Contact / Support</h2>
+          <button type="button" class="close-modal" aria-label="Close contact panel">×</button>
+        </header>
+        <p>List real contact options or support links. Replace this with forms or third-party embeds if needed.</p>
+        <menu class="modal-actions">
+          <button value="cancel" class="ghost">Close</button>
+        </menu>
+      </form>
+    </dialog>
+
+    <script src="script.js" defer></script>
+  </body>
+</html>

--- a/projects/portfolio-microsite/retro.md
+++ b/projects/portfolio-microsite/retro.md
@@ -1,0 +1,22 @@
+# Portfolio Microsite · Retro Template
+
+## Highlights
+- What decisions are you most proud of?
+- Where did you deviate from the original plan (and why)?
+
+## Feedback received
+- Peer feedback summary:
+- Instructor feedback summary:
+- Community/user feedback (if any):
+
+## Accessibility + performance check-in
+- Tools used (e.g., axe DevTools, Lighthouse):
+- Key issues discovered:
+- Fixes you shipped or plan to ship:
+
+## Next iteration ideas
+- Features or content you’d add with another week:
+- Tech debt or refactors to tackle:
+- Collaborators to invite for future iterations:
+
+Close with a screenshot or link to a demo video to document the current state.

--- a/projects/portfolio-microsite/script.js
+++ b/projects/portfolio-microsite/script.js
@@ -1,0 +1,44 @@
+// Portfolio microsite starter interactions
+// Tweak these as you build your subject's story.
+
+const modalTriggerButtons = document.querySelectorAll('[data-modal-target]');
+const accordions = document.querySelectorAll('[data-accordion]');
+
+modalTriggerButtons.forEach((button) => {
+  const targetId = button.dataset.modalTarget;
+  const dialog = document.getElementById(targetId);
+
+  if (!dialog) return;
+
+  button.addEventListener('click', () => {
+    dialog.showModal();
+    dialog.classList.add('is-open');
+  });
+
+  const closeButton = dialog.querySelector('.close-modal');
+  if (closeButton) {
+    closeButton.addEventListener('click', () => {
+      dialog.close();
+      dialog.classList.remove('is-open');
+    });
+  }
+
+  dialog.addEventListener('cancel', (event) => {
+    event.preventDefault();
+    dialog.close();
+    dialog.classList.remove('is-open');
+  });
+});
+
+accordions.forEach((accordion) => {
+  const toggle = accordion.querySelector('.accordion-toggle');
+  const panel = accordion.querySelector('.accordion-panel');
+
+  if (!toggle || !panel) return;
+
+  toggle.addEventListener('click', () => {
+    const isOpen = toggle.getAttribute('aria-expanded') === 'true';
+    toggle.setAttribute('aria-expanded', String(!isOpen));
+    panel.hidden = isOpen;
+  });
+});

--- a/projects/portfolio-microsite/styles.css
+++ b/projects/portfolio-microsite/styles.css
@@ -1,0 +1,268 @@
+:root {
+  color-scheme: light dark;
+  --bg: #030712;
+  --surface: rgba(15, 23, 42, 0.88);
+  --surface-alt: rgba(30, 41, 59, 0.88);
+  --border: rgba(148, 163, 184, 0.2);
+  --text: #f8fafc;
+  --muted: #94a3b8;
+  --accent: #f472b6;
+  --accent-alt: #38bdf8;
+  --radius-lg: 1.75rem;
+  --radius-md: 1rem;
+  font-family: "Soehne", "Inter", system-ui, sans-serif;
+  line-height: 1.6;
+}
+
+body {
+  margin: 0;
+  background: radial-gradient(circle at top, #1d4ed8, var(--bg));
+  color: var(--text);
+}
+
+.skip-links a {
+  position: absolute;
+  left: -999px;
+  top: 0;
+  background: #38bdf8;
+  color: #03122e;
+  padding: 0.75rem 1rem;
+  border-radius: 999px;
+}
+
+.skip-links a:focus {
+  left: 1rem;
+  top: 1rem;
+}
+
+.site-header {
+  padding: 4rem 1.5rem 3rem;
+  max-width: 75rem;
+  margin: 0 auto;
+}
+
+.hero {
+  background: var(--surface);
+  padding: 2.5rem;
+  border-radius: var(--radius-lg);
+  box-shadow: 0 2rem 3.5rem rgba(2, 6, 23, 0.4);
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.lede {
+  max-width: 50ch;
+  color: rgba(248, 250, 252, 0.8);
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
+.button,
+.ghost {
+  border-radius: 999px;
+  font-weight: 700;
+  padding: 0.75rem 1.75rem;
+  cursor: pointer;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.button {
+  background: linear-gradient(135deg, var(--accent), var(--accent-alt));
+  color: #030712;
+  border: none;
+}
+
+.ghost {
+  background: transparent;
+  color: var(--text);
+  border: 1px solid var(--border);
+}
+
+.meta {
+  list-style: none;
+  display: grid;
+  gap: 0.75rem;
+  padding: 0;
+  margin: 2rem 0 0;
+  background: var(--surface-alt);
+  border-radius: var(--radius-lg);
+  padding: 1.75rem 2rem;
+  box-shadow: inset 0 0 0 1px var(--border);
+}
+
+.meta span {
+  color: var(--muted);
+}
+
+.layout {
+  max-width: 75rem;
+  margin: 0 auto;
+  padding: 0 1.5rem 4rem;
+  display: grid;
+  gap: 2.5rem;
+}
+
+.layout section {
+  background: var(--surface);
+  padding: 2.25rem;
+  border-radius: var(--radius-lg);
+  box-shadow: 0 1.75rem 3rem rgba(2, 6, 23, 0.35);
+}
+
+.cards {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.cards article {
+  background: var(--surface-alt);
+  padding: 1.5rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+}
+
+.text-link {
+  color: var(--accent-alt);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.text-link:hover,
+.text-link:focus {
+  color: var(--accent);
+}
+
+.accordion {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  margin-top: 1.5rem;
+}
+
+.accordion-toggle {
+  width: 100%;
+  background: transparent;
+  border: none;
+  color: inherit;
+  text-align: left;
+  padding: 1rem 1.25rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-weight: 600;
+}
+
+.accordion-panel {
+  padding: 0 1.25rem 1.25rem;
+  border-top: 1px solid var(--border);
+}
+
+.timeline {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  border-left: 2px solid var(--border);
+}
+
+.timeline li {
+  position: relative;
+  padding-left: 1.75rem;
+  margin-bottom: 1.5rem;
+}
+
+.timeline time {
+  font-weight: 700;
+  color: var(--accent-alt);
+}
+
+.timeline li::before {
+  content: "";
+  position: absolute;
+  left: -0.55rem;
+  top: 0.4rem;
+  width: 0.8rem;
+  height: 0.8rem;
+  border-radius: 50%;
+  background: var(--accent);
+}
+
+.site-footer {
+  max-width: 75rem;
+  margin: 0 auto 4rem;
+  padding: 0 1.5rem;
+  text-align: center;
+  color: var(--muted);
+}
+
+.modal {
+  border: none;
+  border-radius: var(--radius-lg);
+  background: var(--surface);
+  color: var(--text);
+  width: min(90vw, 32rem);
+  padding: 0;
+}
+
+.modal::backdrop {
+  background: rgba(3, 7, 18, 0.85);
+}
+
+.modal-content {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 2rem;
+}
+
+.modal-content header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.close-modal {
+  border: none;
+  background: transparent;
+  color: inherit;
+  font-size: 1.75rem;
+  cursor: pointer;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+@media (min-width: 60rem) {
+  .hero {
+    display: grid;
+    grid-template-columns: 2fr 1fr;
+    gap: 2rem;
+    align-items: center;
+  }
+
+  .meta {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .layout {
+    grid-template-columns: 2fr 1fr;
+  }
+
+  #featured-work {
+    grid-column: span 2;
+  }
+}

--- a/resources/README.md
+++ b/resources/README.md
@@ -1,0 +1,30 @@
+# Resources & Reference Library
+
+Save yourself from endless tab chaos. Share this list with students and invite them to PR their favorite additions.
+
+## Accessibility
+- [A11y Project Checklist](https://www.a11yproject.com/checklist/) — human-friendly reminders for inclusive builds.
+- [Inclusive Components](https://inclusive-components.design/) — deep dives into accessible UI patterns.
+- [The Readability Guidelines](https://readabilityguidelines.co.uk/) — word nerd magic for clearer copy.
+
+## HTML & CSS essentials
+- [MDN Web Docs](https://developer.mozilla.org/) — canonical reference with examples.
+- [Every Layout](https://every-layout.dev/) — pattern-based approach to layout thinking.
+- [SmolCSS](https://smolcss.dev/) — tiny CSS patterns for quick wins.
+
+## JavaScript sanity
+- [You Might Not Need JavaScript](https://youmightnotneedjs.com/) — push for progressive enhancement.
+- [JavaScript Event Reference](https://developer.mozilla.org/en-US/docs/Web/Events) — find the event you forgot existed.
+- [Open Web Docs DOM Recipes](https://open-wc.org/guides/knowledge/) — bite-sized how-tos.
+
+## Design inspiration
+- [Accessible Color Palette Generator](https://color.review/) — test combos fast.
+- [Are.na](https://www.are.na/explore) — curated mood boards and research trails.
+- [Site Inspire](https://www.siteinspire.com/) — searchable gallery with filters.
+
+## Teaching aids
+- [Teach Access Curriculum](https://teachaccess.github.io/curriculum/) — plug-in modules on accessibility.
+- [Web.dev Learn](https://web.dev/learn/) — structured courses for HTML, CSS, JS.
+- [Frontend Practice](https://www.frontendpractice.com/) — design-to-code challenges for homework.
+
+Encourage students to question every source and document what they learn. Punk-rock pedagogy = critical thinking + open sharing.


### PR DESCRIPTION
## Summary
- overhaul the root README with guidance on how to use the course toolkit
- add three fully-scripted lesson modules with demo code, starters, and diagrams
- introduce exercises, a capstone-ready portfolio project starter, and a shared resources library

## Testing
- not run (static content only)


------
https://chatgpt.com/codex/tasks/task_e_68c884f89c0083259311bec67ce2f1cb